### PR TITLE
Parse directly from string & better improve path handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oui"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["pwrdwnsys <pwrdwnsys@users.noreply.github.com>"]
 description = "Lookup MAC OUI vendor information from the Wireshark manufacturer database"
 repository = "https://github.com/pwrdwnsys/rs-oui"


### PR DESCRIPTION
Changes should not be breaking, incremented minor version.

The changes allow calling `new_from_file` with any `AsRef<Path>` type, such as `&str`, `Path` and `PathBuf` to provide flexibility for the caller.

Further a `new_from_str` associated function allows constructing the database directly from a `&str` for use-cases such as embedding the database with `include_str!`.